### PR TITLE
Register Service provider files denoting mappers for native image

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mapstruct/deployment/MapperServiceProviderProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mapstruct/deployment/MapperServiceProviderProcessor.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.mapstruct.deployment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.logging.Logger;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
+
+public class MapperServiceProviderProcessor {
+
+    private static final Logger LOG = Logger.getLogger(MapperServiceProviderProcessor.class);
+
+    @BuildStep
+    List<ServiceProviderBuildItem> registerMapperServiceProviders(CombinedIndexBuildItem index) {
+
+        // Register all META-INF/services entries for ServiceLoader-based mappers
+        // This enables native mode support for mappers with custom implementationName
+
+        List<ServiceProviderBuildItem> result = new ArrayList<>();
+        // Find all @Mapper annotated interfaces to determine which ones might use ServiceLoader
+        for (AnnotationInstance mapperAnnotation : index.getComputingIndex().getAnnotations(MapstructNames.NAME_MAPPER)) {
+            String mapperClassName = mapperAnnotation.target().asClass().name().toString();
+
+            // This automatically reads META-INF/services/{mapperClassName} if it exists
+            result.add(ServiceProviderBuildItem.allProvidersFromClassPath(mapperClassName));
+            LOG.tracef("Registered ServiceLoader providers for mapper: %s", mapperClassName);
+        }
+
+        return result;
+    }
+}

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,0 +1,3 @@
+:project-version: 0
+
+:examples-dir: ./../examples/

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/basic/QuarkusMapstructResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/basic/QuarkusMapstructResource.java
@@ -26,4 +26,20 @@ public class QuarkusMapstructResource {
         return Mappers.getMapper(AddressMapper.class).getClass().getName() + "|"
                 + Mappers.getMapperClass(AddressMapper.class).getName();
     }
+
+    @Path("test-serviceloader")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String testServiceLoader() {
+        Email email = new Email();
+        email.setEmail("test@example.com");
+
+        // Using custom implementationName forces MapStruct to use ServiceLoader
+        ServiceProviderMapper mapper = Mappers.getMapper(ServiceProviderMapper.class);
+        EmailData emailData = mapper.mapToEmailData(email);
+
+        return mapper.getClass().getName() + "|"
+                + Mappers.getMapperClass(ServiceProviderMapper.class).getName() + "|"
+                + emailData.getEmail();
+    }
 }

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/basic/ServiceProviderMapper.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/basic/ServiceProviderMapper.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.mapstruct.it.basic;
+
+import org.mapstruct.Mapper;
+
+@Mapper(implementationName = "<CLASS_NAME>_")
+public interface ServiceProviderMapper {
+    EmailData mapToEmailData(Email email);
+}

--- a/integration-tests/src/main/resources/META-INF/services/io.quarkiverse.mapstruct.it.basic.ServiceProviderMapper
+++ b/integration-tests/src/main/resources/META-INF/services/io.quarkiverse.mapstruct.it.basic.ServiceProviderMapper
@@ -1,0 +1,1 @@
+io.quarkiverse.mapstruct.it.basic.ServiceProviderMapperCustomImpl

--- a/integration-tests/src/test/java/io/quarkiverse/mapstruct/it/MapstructResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/mapstruct/it/MapstructResourceTest.java
@@ -8,15 +8,25 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-public class MapstructResourceTest {
+class MapstructResourceTest {
 
     @Test
-    public void testHelloEndpoint() {
+    void testHelloEndpoint() {
         given()
                 .when().get("/mapstruct/basic/test")
                 .then()
                 .statusCode(200)
                 .body(is(
                         "io.quarkiverse.mapstruct.it.basic.AddressMapperImpl|io.quarkiverse.mapstruct.it.basic.AddressMapperImpl"));
+    }
+
+    @Test
+    void testServiceLoaderMapperEndpoint() {
+        given()
+                .when().get("/mapstruct/basic/test-serviceloader")
+                .then()
+                .statusCode(200)
+                .body(is(
+                        "io.quarkiverse.mapstruct.it.basic.ServiceProviderMapper_|io.quarkiverse.mapstruct.it.basic.ServiceProviderMapper_|test@example.com"));
     }
 }


### PR DESCRIPTION
Mappers can be retrieved using Mappers.getMapper. Normally this would load a class with Suffix Impl. The suffix can be changed using the implementationPackage config. In this case the getMapper call falls back to using a Service Loader for finding the implementation.

closes #6 