### PR TITLE
Add quarkus-mapstruct-processor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,6 @@ pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
 release.properties
+dependency-reduced-pom.xml
 
 .claude

--- a/ReplaceProcessor.java
+++ b/ReplaceProcessor.java
@@ -1,0 +1,99 @@
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Replaces mapstruct-processor with quarkus-mapstruct-processor in all pom.xml files
+ * found under a given directory (recursively).
+ *
+ * Usage: java ReplaceProcessor.java [examples-dir] [quarkus-mapstruct-processor-version]
+ *   examples-dir: path to mapstruct-examples clone (default: target/mapstruct-examples)
+ *   version:      quarkus-mapstruct-processor version to use (default: 999-SNAPSHOT)
+ */
+public class ReplaceProcessor {
+
+    public static void main(String[] args) throws IOException {
+        Path rootDir = args.length > 0 ? Path.of(args[0]) : Path.of("target/mapstruct-examples");
+        String processorVersion = args.length > 1 ? args[1] : "999-SNAPSHOT";
+
+        if (!Files.isDirectory(rootDir)) {
+            System.err.println("Directory not found: " + rootDir);
+            System.exit(1);
+        }
+
+        System.out.println("Scanning: " + rootDir.toAbsolutePath());
+        System.out.println("Replacing mapstruct-processor with quarkus-mapstruct-processor:" + processorVersion);
+        System.out.println();
+
+        int[] count = {0};
+        try (Stream<Path> stream = Files.walk(rootDir)) {
+            stream.filter(p -> p.getFileName().toString().equals("pom.xml"))
+                  .forEach(pom -> {
+                      if (replaceProcessor(pom, processorVersion)) {
+                          count[0]++;
+                      }
+                  });
+        }
+
+        System.out.println();
+        System.out.println("Done. Modified " + count[0] + " pom.xml file(s).");
+    }
+
+    private static boolean replaceProcessor(Path pom, String version) {
+        try {
+            String original = Files.readString(pom);
+            String modified = replaceProcessorInContent(original, version);
+            if (original.equals(modified)) {
+                return false;
+            }
+            Files.writeString(pom, modified);
+            System.out.println("  Modified: " + pom);
+            return true;
+        } catch (IOException e) {
+            System.err.println("  Error processing " + pom + ": " + e.getMessage());
+            return false;
+        }
+    }
+
+    static String replaceProcessorInContent(String content, String version) {
+        // Step 1: replace the artifactId — unambiguous, no other artifact uses this name
+        String result = content.replace(
+            "<artifactId>mapstruct-processor</artifactId>",
+            "<artifactId>quarkus-mapstruct-processor</artifactId>"
+        );
+
+        if (result.equals(content)) {
+            return content; // nothing to do
+        }
+
+        // Step 2: fix groupId adjacent to the replaced artifactId (handles both element orders)
+        result = Pattern.compile(
+            "<groupId>org\\.mapstruct</groupId>(\\s*<artifactId>quarkus-mapstruct-processor</artifactId>)",
+            Pattern.DOTALL
+        ).matcher(result).replaceAll("<groupId>io.quarkiverse.mapstruct</groupId>$1");
+
+        result = Pattern.compile(
+            "(<artifactId>quarkus-mapstruct-processor</artifactId>\\s*)<groupId>org\\.mapstruct</groupId>",
+            Pattern.DOTALL
+        ).matcher(result).replaceAll("$1<groupId>io.quarkiverse.mapstruct</groupId>");
+
+        // Step 3: fix version adjacent to the replaced block (groupId-first or artifactId-first)
+        result = Pattern.compile(
+            "(<groupId>io\\.quarkiverse\\.mapstruct</groupId>\\s*" +
+             "<artifactId>quarkus-mapstruct-processor</artifactId>\\s*" +
+             "<version>)[^<]*(</version>)",
+            Pattern.DOTALL
+        ).matcher(result).replaceAll("$1" + version + "$2");
+
+        result = Pattern.compile(
+            "(<artifactId>quarkus-mapstruct-processor</artifactId>\\s*" +
+             "<groupId>io\\.quarkiverse\\.mapstruct</groupId>\\s*" +
+             "<version>)[^<]*(</version>)",
+            Pattern.DOTALL
+        ).matcher(result).replaceAll("$1" + version + "$2");
+
+        return result;
+    }
+}

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -76,7 +76,7 @@ However, the extension is always only tested against the newest version of MapSt
 <dependency>
     <groupId>org.mapstruct</groupId>
     <artifactId>mapstruct</artifactId>
-    <version>1.6.3</version>
+    <version>{mapstruct.version}</version>
 </dependency>
 ----
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -26,6 +26,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>
@@ -100,6 +101,11 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
+                <configuration>
+                    <attributes>
+                        <mapstruct.version>${mapstruct.version}</mapstruct.version>
+                    </attributes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.mapstruct</groupId>
@@ -50,6 +50,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <goals>
@@ -83,9 +84,9 @@
                 <configuration>
                     <annotationProcessorPaths>
                         <path>
-                            <groupId>org.mapstruct</groupId>
-                            <artifactId>mapstruct-processor</artifactId>
-                            <version>${mapstruct.version}</version>
+                            <groupId>io.quarkiverse.mapstruct</groupId>
+                            <artifactId>quarkus-mapstruct-processor</artifactId>
+                            <version>${project.parent.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child1.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child1.java
@@ -1,8 +1,8 @@
 package io.quarkiverse.mapstruct.it.configmapping;
 
-import io.smallrye.config.ConfigMapping;
-
 import java.util.List;
+
+import io.smallrye.config.ConfigMapping;
 
 @ConfigMapping(beanStyleGetters = true)
 public interface Child1 {

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child1.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child1.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+import io.smallrye.config.ConfigMapping;
+
+import java.util.List;
+
+@ConfigMapping(beanStyleGetters = true)
+public interface Child1 {
+    String prop();
+
+    List<Child2> childs();
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child1BeanStyle.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child1BeanStyle.java
@@ -1,0 +1,9 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+import java.util.List;
+
+public interface Child1BeanStyle {
+    String getProp();
+
+    List<Child2> getChilds();
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child1Model.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child1Model.java
@@ -1,0 +1,9 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+import java.util.List;
+
+public class Child1Model {
+    public String prop;
+
+    public List<Child2Model> childs;
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child2.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child2.java
@@ -1,0 +1,5 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+public interface Child2 {
+    String prop();
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child2Beanstyle.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child2Beanstyle.java
@@ -1,0 +1,5 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+public interface Child2Beanstyle {
+    String getProp();
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child2Model.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Child2Model.java
@@ -1,0 +1,5 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+public class Child2Model {
+    public String prop;
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/ConfigMappingResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/ConfigMappingResource.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.common.MapBackedConfigSource;
+
+@ApplicationScoped
+@Path("mapstruct/configmapping")
+public class ConfigMappingResource {
+
+    @Inject
+    ParentMapper mapper;
+
+    private SmallRyeConfig buildConfig() {
+        MapBackedConfigSource source = new MapBackedConfigSource("ConfigMappingResource",
+                Map.of(
+                        "parent.prop", "Value1",
+                        "parent.childs[0].prop", "Value2",
+                        "parent.childs[0].childs[0].prop", "Value3",
+                        "parent.childs[0].childs[1].prop", "Value4",
+                        "parent.childs[1].prop", "Value5",
+                        "parent.childs[1].childs[0].prop", "Value6",
+                        "parent.childs[1].childs[1].prop", "Value7")) {
+        };
+
+        return new SmallRyeConfigBuilder()
+                .withSources(source)
+                .withMapping(Parent.class)
+                .withMapping(ParentBeanStyle.class)
+                .build();
+    }
+
+    @Path("test")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ParentModel hello() {
+        SmallRyeConfig smallRyeConfig = buildConfig();
+        ParentModel model = mapper.map(smallRyeConfig.getConfigMapping(Parent.class));
+
+        return model;
+    }
+
+    @Path("test-bean-style")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ParentModel helloBeanStyle() {
+        SmallRyeConfig smallRyeConfig = buildConfig();
+        ParentModel model = mapper.map(smallRyeConfig.getConfigMapping(ParentBeanStyle.class));
+
+        return model;
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Parent.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/Parent.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+import java.util.List;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "parent")
+public interface Parent {
+    String prop();
+
+    List<Child1> childs();
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/ParentBeanStyle.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/ParentBeanStyle.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+import java.util.List;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "parent", beanStyleGetters = true)
+public interface ParentBeanStyle {
+    String getProp();
+
+    List<Child1> getChilds();
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/ParentMapper.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/ParentMapper.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "jakarta-cdi")
+public interface ParentMapper {
+    ParentModel map(Parent config);
+
+    ParentModel map(ParentBeanStyle config);
+}

--- a/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/ParentModel.java
+++ b/integration-tests/src/main/java/io/quarkiverse/mapstruct/it/configmapping/ParentModel.java
@@ -1,0 +1,9 @@
+package io.quarkiverse.mapstruct.it.configmapping;
+
+import java.util.List;
+
+public class ParentModel {
+    public String prop;
+
+    public List<Child1Model> childs;
+}

--- a/integration-tests/src/test/java/io/quarkiverse/mapstruct/it/ConfigMappingResourceIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/mapstruct/it/ConfigMappingResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.mapstruct.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ConfigMappingResourceIT extends ConfigMappingResourceTest {
+}

--- a/integration-tests/src/test/java/io/quarkiverse/mapstruct/it/ConfigMappingResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/mapstruct/it/ConfigMappingResourceTest.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.mapstruct.it;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ConfigMappingResourceTest {
+
+    @Test
+    void test() {
+        given()
+                .when().get("/mapstruct/configmapping/test")
+                .then()
+                .statusCode(200)
+                .body("prop", is("Value1"))
+                .body("childs[0].prop", is("Value2"))
+                .body("childs[0].childs[0].prop", is("Value3"))
+                .body("childs[0].childs[1].prop", is("Value4"))
+                .body("childs[1].prop", is("Value5"))
+                .body("childs[1].childs[0].prop", is("Value6"))
+                .body("childs[1].childs[1].prop", is("Value7"));
+    }
+
+    @Test
+    void testBeanStyle() {
+        given()
+                .when().get("/mapstruct/configmapping/test-bean-style")
+                .then()
+                .statusCode(200)
+                .body("prop", is("Value1"))
+                .body("childs[0].prop", is("Value2"))
+                .body("childs[0].childs[0].prop", is("Value3"))
+                .body("childs[0].childs[1].prop", is("Value4"))
+                .body("childs[1].prop", is("Value5"))
+                .body("childs[1].childs[0].prop", is("Value6"))
+                .body("childs[1].childs[1].prop", is("Value7"));
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/mapstruct/it/ConfigMappingTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/mapstruct/it/ConfigMappingTest.java
@@ -1,0 +1,59 @@
+package io.quarkiverse.mapstruct.it;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(ConfigMappingTest.class)
+public class ConfigMappingTest implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "parent.prop", "Value1",
+                "parent.childs[0].prop", "Value2",
+                "parent.childs[0].childs[0].prop", "Value3",
+                "parent.childs[0].childs[1].prop", "Value4",
+                "parent.childs[1].prop", "Value5",
+                "parent.childs[1].childs[0].prop", "Value6",
+                "parent.childs[1].childs[1].prop", "Value7");
+    }
+
+    @Test
+    public void test() {
+        given()
+                .when().get("/mapstruct/configmapping/test")
+                .then()
+                .statusCode(200)
+                .body("prop", is("Value1"))
+                .body("childs[0].prop", is("Value2"))
+                .body("childs[0].childs[0].prop", is("Value3"))
+                .body("childs[0].childs[1].prop", is("Value4"))
+                .body("childs[1].prop", is("Value5"))
+                .body("childs[1].childs[0].prop", is("Value6"))
+                .body("childs[1].childs[1].prop", is("Value7"));
+    }
+
+    @Test
+    public void testBeanStyle() {
+        given()
+                .when().get("/mapstruct/configmapping/test-bean-style")
+                .then()
+                .statusCode(200)
+                .body("prop", is("Value1"))
+                .body("childs[0].prop", is("Value2"))
+                .body("childs[0].childs[0].prop", is("Value3"))
+                .body("childs[0].childs[1].prop", is("Value4"))
+                .body("childs[1].prop", is("Value5"))
+                .body("childs[1].childs[0].prop", is("Value6"))
+                .body("childs[1].childs[1].prop", is("Value7"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>processor</module>
     </modules>
 
     <scm>
@@ -31,6 +32,8 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <compiler-plugin.version>3.14.1</compiler-plugin.version>
+        <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+
         <quarkus.version>3.31.0</quarkus.version>
         <mapstruct.version>1.6.3</mapstruct.version>
     </properties>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.mapstruct</groupId>
+        <artifactId>quarkus-mapstruct-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-mapstruct-processor</artifactId>
+    <name>Quarkus Mapstruct - Processor</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+            <!--
+                Dependency plugin instead of shade
+                shade plugin works on the build artifact of this project. But that is too late.
+                In a reactor build maven resolves other modules, but uses their target/classes/ instead of the built artifact.
+                I.e. shade is too late.
+                dependency plugin works by replacing / expanding the target/classes content.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-mapstruct-processor</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.mapstruct</groupId>
+                                    <artifactId>mapstruct-processor</artifactId>
+                                    <version>${mapstruct.version}</version>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                    <excludes>META-INF/services/javax.annotation.processing.Processor</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/processor/src/main/java/io/quarkiverse/mapstruct/processor/QuarkusMapStructProcessor.java
+++ b/processor/src/main/java/io/quarkiverse/mapstruct/processor/QuarkusMapStructProcessor.java
@@ -1,0 +1,158 @@
+package io.quarkiverse.mapstruct.processor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.annotation.processing.Completion;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+import org.mapstruct.ap.MappingProcessor;
+
+import io.quarkiverse.mapstruct.processor.spi.ConfigMappingTypes;
+
+/**
+ * A delegating annotation processor that wraps MapStruct's {@link MappingProcessor}.
+ * This allows Quarkus-specific customizations to be added around the MapStruct processing.
+ *
+ * <p>
+ * Collected {@code @ConfigMapping} types are persisted to a resource file so they survive
+ * across incremental compilations. The {@link ConfigMappingTypes} class reads from
+ * this file and is used by the {@code QuarkusAccessorNamingStrategy} SPI.
+ */
+public class QuarkusMapStructProcessor implements Processor {
+
+    private static final String CONFIG_MAPPING_ANNOTATION = "io.smallrye.config.ConfigMapping";
+
+    private final MappingProcessor delegate = new MappingProcessor();
+    private ProcessingEnvironment processingEnv;
+    private Path resourceFilePath;
+    private final Set<String> collectedTypes = new HashSet<>();
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return delegate.getSupportedOptions();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return delegate.getSupportedAnnotationTypes();
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return delegate.getSupportedSourceVersion();
+    }
+
+    @Override
+    public void init(ProcessingEnvironment processingEnv) {
+        this.processingEnv = processingEnv;
+
+        try {
+            FileObject fo = processingEnv.getFiler()
+                    .getResource(StandardLocation.CLASS_OUTPUT, "", ConfigMappingTypes.RESOURCE_FILE);
+            resourceFilePath = Path.of(fo.toUri());
+        } catch (IOException e) {
+            // Cannot determine output path
+        }
+
+        ConfigMappingTypes.setResourceFilePath(resourceFilePath);
+
+        // Load types from a previous compilation (incremental builds)
+        collectedTypes.addAll(ConfigMappingTypes.get());
+
+        delegate.init(processingEnv);
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        collectConfigMappings(roundEnv);
+        writeTypesToFile();
+        return delegate.process(annotations, roundEnv);
+    }
+
+    @Override
+    public Iterable<? extends Completion> getCompletions(Element element, AnnotationMirror annotation,
+            ExecutableElement member, String userText) {
+        return delegate.getCompletions(element, annotation, member, userText);
+    }
+
+    private void collectConfigMappings(RoundEnvironment roundEnv) {
+        TypeElement configMappingAnnotation = processingEnv.getElementUtils()
+                .getTypeElement(CONFIG_MAPPING_ANNOTATION);
+        if (configMappingAnnotation == null) {
+            return;
+        }
+
+        for (Element element : roundEnv.getElementsAnnotatedWith(configMappingAnnotation)) {
+            if (element instanceof TypeElement typeElement) {
+                collectConfigMappingType(typeElement);
+            }
+        }
+    }
+
+    private void collectConfigMappingType(TypeElement typeElement) {
+        if (!collectedTypes.add(typeElement.getQualifiedName().toString())) {
+            return;
+        }
+
+        for (Element enclosed : typeElement.getEnclosedElements()) {
+            if (enclosed.getKind() == ElementKind.METHOD) {
+                ExecutableElement method = (ExecutableElement) enclosed;
+                collectNestedConfigMappings(method.getReturnType());
+            }
+        }
+    }
+
+    private void collectNestedConfigMappings(TypeMirror typeMirror) {
+        if (typeMirror.getKind() != TypeKind.DECLARED) {
+            return;
+        }
+
+        DeclaredType declaredType = (DeclaredType) typeMirror;
+        Element element = declaredType.asElement();
+
+        // Recurse into type arguments first (e.g. Optional<Nested>, List<Nested>, Map<String, Nested>)
+        for (TypeMirror typeArg : declaredType.getTypeArguments()) {
+            collectNestedConfigMappings(typeArg);
+        }
+
+        // Only collect non-JDK interfaces as config mapping types
+        if (element.getKind() == ElementKind.INTERFACE) {
+            TypeElement nested = (TypeElement) element;
+            String name = nested.getQualifiedName().toString();
+            if (!name.startsWith("java.")) {
+                collectConfigMappingType(nested);
+            }
+        }
+    }
+
+    private void writeTypesToFile() {
+        if (resourceFilePath == null || collectedTypes.isEmpty()) {
+            return;
+        }
+        try {
+            Files.createDirectories(resourceFilePath.getParent());
+            Files.write(resourceFilePath, new TreeSet<>(collectedTypes));
+            ConfigMappingTypes.invalidateCache();
+        } catch (IOException e) {
+            // Silently ignore - types from the current compilation are still available via the cache
+        }
+    }
+}

--- a/processor/src/main/java/io/quarkiverse/mapstruct/processor/spi/ConfigMappingTypes.java
+++ b/processor/src/main/java/io/quarkiverse/mapstruct/processor/spi/ConfigMappingTypes.java
@@ -1,0 +1,74 @@
+package io.quarkiverse.mapstruct.processor.spi;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Provides access to the set of fully qualified names of types that belong to a
+ * {@code @ConfigMapping} interface hierarchy.
+ *
+ * <p>
+ * Types are persisted to a resource file by the annotation processor so they survive
+ * across incremental compilations. This class reads from that file.
+ */
+public final class ConfigMappingTypes {
+
+    public static final String RESOURCE_FILE = "META-INF/quarkus-mapstruct/config-mapping-types";
+
+    private static volatile Path resourceFilePath;
+    private static volatile Set<String> cachedTypes;
+
+    private ConfigMappingTypes() {
+    }
+
+    /**
+     * Sets the path to the resource file. Called by the annotation processor during initialization.
+     */
+    public static void setResourceFilePath(Path path) {
+        resourceFilePath = path;
+        cachedTypes = null;
+    }
+
+    /**
+     * Invalidates the cached types so the next call to {@link #get()} re-reads the file.
+     */
+    public static void invalidateCache() {
+        cachedTypes = null;
+    }
+
+    /**
+     * Returns the set of fully qualified names of types that belong to a
+     * {@code @ConfigMapping} interface hierarchy.
+     */
+    public static Set<String> get() {
+        Set<String> types = cachedTypes;
+        if (types != null) {
+            return types;
+        }
+        types = readTypesFromFile();
+        cachedTypes = types;
+        return types;
+    }
+
+    private static Set<String> readTypesFromFile() {
+        Path path = resourceFilePath;
+        if (path == null || !Files.exists(path)) {
+            return Collections.emptySet();
+        }
+        try {
+            Set<String> types = new HashSet<>();
+            for (String line : Files.readAllLines(path)) {
+                if (!line.isBlank()) {
+                    types.add(line.trim());
+                }
+            }
+            return Collections.unmodifiableSet(types);
+        } catch (IOException e) {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/processor/src/main/java/io/quarkiverse/mapstruct/processor/spi/QuarkusAccessorNamingStrategy.java
+++ b/processor/src/main/java/io/quarkiverse/mapstruct/processor/spi/QuarkusAccessorNamingStrategy.java
@@ -1,0 +1,66 @@
+package io.quarkiverse.mapstruct.processor.spi;
+
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+
+import org.mapstruct.ap.spi.DefaultAccessorNamingStrategy;
+
+/**
+ * AccessorNamingStrategy which tells mapstruct how to deal with ConfigMap like interfaces.
+ */
+public class QuarkusAccessorNamingStrategy extends DefaultAccessorNamingStrategy {
+
+    // TODO: bean style https://github.com/smallrye/smallrye-config/pull/1239/changes#diff-4841b7c8b98472d1ee27bdb4ca04e63f8f793e7c5d7f6089dc06b0bcd1e9568d
+
+    @Override
+    public boolean isGetterMethod(ExecutableElement method) {
+        if (!isConfigMappingType(method)) {
+            return super.isGetterMethod(method);
+        }
+
+        if (method.isDefault()) {
+            return false;
+        }
+
+        // For ConfigMapping interfaces, all no-arg methods are getters
+        return method.getParameters().isEmpty();
+    }
+
+    @Override
+    public String getPropertyName(ExecutableElement method) {
+        if (!isConfigMappingType(method)) {
+            return super.getPropertyName(method);
+        }
+
+        // For ConfigMapping interfaces, the method name IS the property name (e.g., path() -> path)
+        return method.getSimpleName().toString();
+    }
+
+    @Override
+    public boolean isSetterMethod(ExecutableElement method) {
+        if (!isConfigMappingType(method)) {
+            return super.isSetterMethod(method);
+        }
+
+        return false;
+    }
+
+    @Override
+    protected boolean isFluentSetter(ExecutableElement method) {
+        if (!isConfigMappingType(method)) {
+            return super.isFluentSetter(method);
+        }
+
+        return false;
+    }
+
+    private boolean isConfigMappingType(ExecutableElement method) {
+        if (method.getEnclosingElement().getKind() != ElementKind.INTERFACE) {
+            return false;
+        }
+        TypeElement enclosing = (TypeElement) method.getEnclosingElement();
+        return ConfigMappingTypes.get()
+                .contains(enclosing.getQualifiedName().toString());
+    }
+}

--- a/processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+io.quarkiverse.mapstruct.processor.QuarkusMapStructProcessor,isolating

--- a/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+io.quarkiverse.mapstruct.processor.QuarkusMapStructProcessor

--- a/processor/src/main/resources/META-INF/services/org.mapstruct.ap.spi.AccessorNamingStrategy
+++ b/processor/src/main/resources/META-INF/services/org.mapstruct.ap.spi.AccessorNamingStrategy
@@ -1,0 +1,1 @@
+io.quarkiverse.mapstruct.processor.spi.QuarkusAccessorNamingStrategy

--- a/test-mapstruct-examples.sh
+++ b/test-mapstruct-examples.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXAMPLES_DIR="target/mapstruct-examples"
+PROCESSOR_VERSION="${QUARKUS_MAPSTRUCT_VERSION:-999-SNAPSHOT}"
+
+# Clone mapstruct-examples if not already present
+if [ ! -d "$EXAMPLES_DIR" ]; then
+  git clone https://github.com/mapstruct/mapstruct-examples "$EXAMPLES_DIR"
+fi
+
+# Replace mapstruct-processor with quarkus-mapstruct-processor in all pom.xml files
+java ReplaceProcessor.java "$EXAMPLES_DIR" "$PROCESSOR_VERSION"
+
+cd "$EXAMPLES_DIR"
+
+mvn clean install


### PR DESCRIPTION
TODO:

* doc
* Either fully implement beanstyle support, or remove it for now. We should probably just allow beanstlye getters, even if the configmapping does not explciitly allow it. Seems to complicated to test for it. A -> B -> C. What beanstyle does C have? I.e. I don't believe that that mapstruct mapper knows what parents objects are in the chain, because each mapping method is potentially reusable
* The custom NamingAccessor clashes with other user provides naming accessors.