### PR TITLE
Fix appearance of bulleted list

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -42,6 +42,7 @@ public class AddressResource {
  <2> throws a ClassNotFoundException
 
 This extension automatically takes care of registering all:
+
 * `@Mapper` annotated classes
 * classes referenced in the `uses` attribute of the Mapper itself, and from the referenced `@MapperConfig`,
 * The decorator type from `@DecoratedWith`


### PR DESCRIPTION
Noticed while reading the documentation that the bullets were being rendered as asterisks because they didn't have a new line above